### PR TITLE
Add basic Angular + Express skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+# Tinder-like Web Application
 
+This repository provides a very small example of a Tinder-style app built with Angular on the front end and Express.js on the back end.
+
+- The Angular project is located in `client/`.
+- The Express server is located in `server/`.
+
+## Getting Started
+
+Install dependencies and run both projects in separate terminals:
+
+```
+cd server && npm install && npm start
+```
+
+```
+cd client && npm install && ng serve
+```
+
+The client expects the API server to be running on `http://localhost:3000`.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,12 @@
+# Angular Client
+
+This is a minimal Angular application for the Tinder-like demo.
+
+## Development server
+
+```
+npm install
+ng serve
+```
+
+The app will be available at `http://localhost:4200/`.

--- a/client/angular.json
+++ b/client/angular.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/angular-cli",
+  "version": 1,
+  "projects": {
+    "client": {
+      "projectType": "application",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "options": {
+            "outputPath": "dist/client",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "options": {
+            "browserTarget": "client:build"
+          }
+        }
+      }
+    }
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "tinder-like-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/router": "^17.0.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.3.0",
+    "zone.js": "^0.14.0"
+  },
+  "devDependencies": {
+    "@angular/cli": "^17.0.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <nav>
+      <a routerLink="/login">Login</a> |
+      <a routerLink="/register">Register</a> |
+      <a routerLink="/profile">Profile</a> |
+      <a routerLink="/swipe">Swipe</a>
+    </nav>
+    <router-outlet></router-outlet>
+  `
+})
+export class AppComponent {}

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterModule, Routes } from '@angular/router';
+
+import { AppComponent } from './app.component';
+import { LoginComponent } from './login/login.component';
+import { RegisterComponent } from './register/register.component';
+import { ProfileComponent } from './profile/profile.component';
+import { SwipeComponent } from './swipe/swipe.component';
+
+const routes: Routes = [
+  { path: 'login', component: LoginComponent },
+  { path: 'register', component: RegisterComponent },
+  { path: 'profile', component: ProfileComponent },
+  { path: 'swipe', component: SwipeComponent },
+  { path: '', redirectTo: 'login', pathMatch: 'full' }
+];
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    LoginComponent,
+    RegisterComponent,
+    ProfileComponent,
+    SwipeComponent
+  ],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    HttpClientModule,
+    RouterModule.forRoot(routes)
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/client/src/app/login/login.component.ts
+++ b/client/src/app/login/login.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login',
+  template: `
+    <h2>Login</h2>
+    <form (submit)="login()">
+      <label>Username <input [(ngModel)]="username" name="username"></label>
+      <label>Password <input type="password" [(ngModel)]="password" name="password"></label>
+      <button type="submit">Login</button>
+    </form>
+    <p *ngIf="error">{{error}}</p>
+  `
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  error = '';
+
+  constructor(private http: HttpClient, private router: Router) {}
+
+  login() {
+    this.http.post('/api/login', { username: this.username, password: this.password })
+      .subscribe({
+        next: () => {
+          localStorage.setItem('username', this.username);
+          this.router.navigate(['/swipe']);
+        },
+        error: () => this.error = 'Invalid credentials'
+      });
+  }
+}

--- a/client/src/app/profile/profile.component.ts
+++ b/client/src/app/profile/profile.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-profile',
+  template: `
+    <h2>Profile</h2>
+    <div *ngIf="profile">
+      <p><b>Username:</b> {{profile.username}}</p>
+    </div>
+  `
+})
+export class ProfileComponent implements OnInit {
+  profile: any;
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    const username = localStorage.getItem('username');
+    if (username) {
+      this.http.get(`/api/profile/${username}`).subscribe(data => this.profile = data);
+    }
+  }
+}

--- a/client/src/app/register/register.component.ts
+++ b/client/src/app/register/register.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-register',
+  template: `
+    <h2>Register</h2>
+    <form (submit)="register()">
+      <label>Username <input [(ngModel)]="username" name="username"></label>
+      <label>Password <input type="password" [(ngModel)]="password" name="password"></label>
+      <button type="submit">Register</button>
+    </form>
+    <p *ngIf="message">{{message}}</p>
+  `
+})
+export class RegisterComponent {
+  username = '';
+  password = '';
+  message = '';
+
+  constructor(private http: HttpClient, private router: Router) {}
+
+  register() {
+    this.http.post('/api/register', { username: this.username, password: this.password })
+      .subscribe({
+        next: () => {
+          this.message = 'Registration complete';
+          this.router.navigate(['/login']);
+        },
+        error: () => this.message = 'Registration failed'
+      });
+  }
+}

--- a/client/src/app/swipe/swipe.component.ts
+++ b/client/src/app/swipe/swipe.component.ts
@@ -1,0 +1,76 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+interface User {
+  username: string;
+}
+
+@Component({
+  selector: 'app-swipe',
+  template: `
+    <h2>Swipe</h2>
+    <div *ngIf="current">
+      <p>{{current.username}}</p>
+      <button (click)="like()">Like</button>
+      <button (click)="dislike()">Dislike</button>
+    </div>
+    <h3>Matches</h3>
+    <ul>
+      <li *ngFor="let m of matches">{{m}}</li>
+    </ul>
+  `
+})
+export class SwipeComponent implements OnInit {
+  users: User[] = [];
+  current?: User;
+  matches: string[] = [];
+  me: string = '';
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.me = localStorage.getItem('username') || '';
+    this.loadUsers();
+    this.loadMatches();
+  }
+
+  loadUsers() {
+    this.http.get<User[]>('/api/users').subscribe(data => {
+      this.users = data.filter(u => u.username !== this.me);
+      this.next();
+    });
+  }
+
+  loadMatches() {
+    if (this.me) {
+      this.http.get<string[]>(`/api/matches/${this.me}`).subscribe(data => this.matches = data);
+    }
+  }
+
+  next() {
+    this.current = this.users.pop();
+  }
+
+  like() {
+    if (this.current) {
+      this.swipe('right');
+    }
+  }
+
+  dislike() {
+    if (this.current) {
+      this.swipe('left');
+    }
+  }
+
+  swipe(direction: 'left' | 'right') {
+    this.http.post('/api/swipe', {
+      fromUser: this.me,
+      toUser: this.current!.username,
+      direction
+    }).subscribe(() => {
+      this.loadMatches();
+      this.next();
+    });
+  }
+}

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Tinder Like App</title>
+  <base href="/">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav a { margin-right: 10px; }
+button { margin: 5px; }

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2020",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2020", "dom"]
+  }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,10 @@
+# Express Server
+
+Run the API server for the Tinder-like demo.
+
+```
+npm install
+npm start
+```
+
+The server listens on port 3000 and exposes `/api` routes.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,69 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+
+const app = express();
+const PORT = 3000;
+
+app.use(cors());
+app.use(bodyParser.json());
+
+const users = [];
+const swipes = [];
+
+function findUser(username) {
+  return users.find(u => u.username === username);
+}
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body;
+  if (findUser(username)) {
+    return res.status(400).json({ error: 'User exists' });
+  }
+  users.push({ username, password });
+  res.json({ message: 'Registered' });
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = findUser(username);
+  if (!user || user.password !== password) {
+    return res.status(400).json({ error: 'Invalid credentials' });
+  }
+  res.json({ message: 'Login ok' });
+});
+
+app.get('/api/profile/:username', (req, res) => {
+  const user = findUser(req.params.username);
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+  res.json({ username: user.username });
+});
+
+app.get('/api/users', (req, res) => {
+  res.json(users);
+});
+
+app.post('/api/swipe', (req, res) => {
+  const { fromUser, toUser, direction } = req.body;
+  swipes.push({ fromUser, toUser, direction });
+  res.json({ message: 'Recorded' });
+});
+
+app.get('/api/matches/:username', (req, res) => {
+  const username = req.params.username;
+  const likesFromUser = swipes.filter(s => s.fromUser === username && s.direction === 'right');
+  const likesToUser = swipes.filter(s => s.toUser === username && s.direction === 'right');
+
+  const matches = [];
+  for (const like of likesFromUser) {
+    const reciprocal = likesToUser.find(s => s.fromUser === like.toUser && s.toUser === username);
+    if (reciprocal) {
+      matches.push(like.toUser);
+    }
+  }
+  res.json(matches);
+});
+
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tinder-like-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2"
+  }
+}


### PR DESCRIPTION
## Summary
- create Angular frontend skeleton with login, register, profile and swipe components
- add Express backend with simple in-memory auth and matching
- document how to run client and server

## Testing
- `node server/index.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684033486ad48325af3693747d42e649